### PR TITLE
Update “Donate” page link

### DIFF
--- a/donate.html
+++ b/donate.html
@@ -57,9 +57,9 @@
       <div class="row py-4">
         <div class="col-sm-12 py-2 my-auto">
           <h3 class="display-4">Donations</h3>
-          <p>Love what we do? Please consider <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Baltimore">donating</a> to our community so that we can continue growing. Any level of donation ensures that we can accomplish our mission.</p>
+          <p>Love what we do? Please consider <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Baltimore&utm_source=CodeForBaltimore%20site">donating</a> to our community so that we can continue growing. Any level of donation ensures that we can accomplish our mission.</p>
 
-          <a role="button" class="btn btn-outline-primary text-center my-4" href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20Baltimore">Donate</a>
+          <a role="button" class="btn btn-outline-primary text-center my-4" href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20Baltimore&utm_source=CodeForBaltimore%20site">Donate</a>
 
 
           <p>While not required by any means, we strongly encourage members to commit to a $5 monthly donation to support both Community and Hack Nights (snacks and drinks) along with other logistics (website management, Slack, etc.). We commit to being transparent about our finances, check them out <a href="https://docs.google.com/spreadsheets/d/15gDSzLBlnxXVBoo_pD55G8oTnr30B_GUs_07TbMDZAI/edit">here</a>.</p>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ